### PR TITLE
Add option to match triggers anywhere in the message

### DIFF
--- a/DickieBot.py
+++ b/DickieBot.py
@@ -19,7 +19,15 @@ TOKEN = os.getenv('DISCORD_TOKEN')
 DATABASE = os.getenv('DATABASE')
 OWNER = os.getenv('OWNER')
 WEATHERAPIKEY = os.getenv('OWMAPIKEY')
-SOURCE = os.getenv('SOURCE') 
+SOURCE = os.getenv('SOURCE')
+
+#backward-compatible config file options
+try:
+    TRIGGER_ANYWHERE = (int(os.getenv('TRIGGER_ANYWHERE')) == 1)
+    print("TRIGGER_ANYWHERE is", TRIGGER_ANYWHERE)
+except TypeError:
+    TRIGGER_ANYWHERE = False
+
 intents = discord.Intents.all()
 
 db = Connection(DATABASE)
@@ -164,7 +172,7 @@ async def on_message(message):
         msgInParts = msgIn.split('$self')
         msgIn = '$self'.join(e.translate(str.maketrans(dict.fromkeys(string.punctuation))).lower() for e in msgInParts).strip()
 
-        id, msgOut, reaction = db.getFact(msgIn,nsfwTag)
+        id, msgOut, reaction = db.getFact(msgIn,nsfwTag,TRIGGER_ANYWHERE)
         if id: print(f'Triggered {id} with {msgIn}')
 
         # If factoid not triggered by incoming message, check for random

--- a/dbFunctions.py
+++ b/dbFunctions.py
@@ -405,7 +405,7 @@ class Connection:
 
         return(success, known, id)
 
-    def getFact(self, trigger, nsfw):
+    def getFact(self, trigger, nsfw, anywhere=False):
         success = False
         msgOut = None
         id = None
@@ -421,9 +421,15 @@ class Connection:
                 c = self.conn.execute(sql)
             else:
                 # Triggered Factoid
+
+                if anywhere:
+                    trigger_cond = "instr(?, TRIGGER)"
+                else:
+                    trigger_cond = "TRIGGER = ?"
+
                 sql = f"""
                     select ID, MSG, REACTION from FACTS 
-                    where DELETED = 0 and TRIGGER IS NOT NULL and TRIGGER = ? and NSFW in ("""+','.join(str(n) for n in sqlIn)+""") 
+                    where DELETED = 0 and TRIGGER IS NOT NULL and """ + trigger_cond + """ and NSFW in ("""+','.join(str(n) for n in sqlIn)+""") 
                     order by RANDOM() limit 1
                 """
                 c = self.conn.execute(sql,(trigger,))


### PR DESCRIPTION
You just set TRIGGER_ANYWHERE to 1 in the shell environment (or
.env file). I recognize this is probably dangerous and/or annoying,
so it obviously defaults to off.