### PR TITLE
Convert "trigger anywhere" from botwide setting to per-fact

### DIFF
--- a/DickieBot.py
+++ b/DickieBot.py
@@ -218,7 +218,7 @@ async def on_message(message):  # noqa: C901
             for e in msgInParts
         ).strip()
 
-        id, msgOut, reaction = db.getFact(msgIn, nsfwTag, TRIGGER_ANYWHERE)
+        id, msgOut, reaction = db.getFact(msgIn, nsfwTag)
         if id:
             print(f"Triggered {id} with {msgIn}")
 
@@ -230,7 +230,8 @@ async def on_message(message):  # noqa: C901
 
         if id is None and randomNum <= db.getFreq(message.guild.id, message.channel.id):
             id, msgOut, reaction = db.getFact(None, nsfwTag)
-            cap = True if msgOut.startswith("$item") else False
+            if msgOut.startswith("$item"):
+                cap = True
             print(f"Triggered {id}")
 
         # Update called metrics for factoid if called
@@ -280,7 +281,7 @@ def main():
     bot.add_cog(general.General(bot, SOURCE))
     bot.add_cog(info.Information(bot, WEATHERAPIKEY))
     bot.add_cog(inventory.Inventory(bot, db))
-    bot.add_cog(factoids.Factoids(bot, db, OWNER))
+    bot.add_cog(factoids.Factoids(bot, db, OWNER, TRIGGER_ANYWHERE))
     bot.run(TOKEN)
 
 

--- a/DickieBot.py
+++ b/DickieBot.py
@@ -20,12 +20,8 @@ OWNER = os.getenv("OWNER")
 WEATHERAPIKEY = os.getenv("OWMAPIKEY")
 SOURCE = os.getenv("SOURCE")
 
-# backward-compatible config file options
-try:
-    TRIGGER_ANYWHERE = int(os.getenv("TRIGGER_ANYWHERE")) == 1
-    print("TRIGGER_ANYWHERE is", TRIGGER_ANYWHERE)
-except TypeError:
-    TRIGGER_ANYWHERE = False
+# optional config file options
+TRIGGER_ANYWHERE = int(os.getenv("TRIGGER_ANYWHERE", default=0)) == 1
 
 intents = discord.Intents.all()
 

--- a/cogs/factoids.py
+++ b/cogs/factoids.py
@@ -14,10 +14,11 @@ DEFAULTPERC = 5
 
 
 class Factoids(commands.Cog):
-    def __init__(self, bot, db: dbFunctions.Connection, owner):
+    def __init__(self, bot, db: dbFunctions.Connection, owner, match_anywhere_by_default):
         self.bot = bot
         self.db = db
         self.owner = owner
+        self.match_anywhere_by_default = match_anywhere_by_default
 
         self.noList = [
             "https://c.tenor.com/2yJBnYOY_j8AAAAC/tonton-tonton-sticker.gif",
@@ -315,6 +316,7 @@ class Factoids(commands.Cog):
                     ctx.message.author.display_name,
                     ctx.message.author.id,
                     0,
+                    self.match_anywhere_by_default,
                 )
 
                 if success:
@@ -374,6 +376,7 @@ class Factoids(commands.Cog):
                     ctx.message.author.display_name,
                     ctx.message.author.id,
                     1,
+                    self.match_anywhere_by_default,
                 )
 
                 if success:


### PR DESCRIPTION
This requires a schema update, so I also added some very basic schema
versioning stuff. v0 = pre-versioning, v1 = pre-this-update, v2 =
supports "match anywhere" functionality.

The global option still exists, and this just controls how new facts are
created. If TRIGGER_ANYWHERE is in the environment as 1, then new facts
will be created with MATCH_ANYWHERE set. If it is set to 0 or not set,
then new facts will NOT match anywhere. Currently the "recommended"
"procedure" for having facts that buck the global trend, would be for
the admin to use the sqlite3 command-line tool to manually alter the
fact in the database.