### PR TITLE
Get stuff working with python 3.11

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,5 @@ max-line-length = 88
 max-complexity = 18
 #select = B,C,E,F,W,T4,B9,N
 exclude=.venv,.git,dist,*egg,build,*pb2*.py
+per-file-ignores=
+       DickieBot.py:C901

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 config/
 *.env
+*.db
 dickiebase/DickieBot.db
 __pycache__/
 cogs/__pycache__/
 .venv
-log/
+*.code-workspace

--- a/DickieBot.py
+++ b/DickieBot.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # DickieBot: The Impressionable Discord Bot
 
+import asyncio
 import os
 import discord
 import re
@@ -36,6 +37,7 @@ GH_user, GH_token, GH_repo = GH_USR_PW_REPO.split(",")
 TRIGGER_ANYWHERE = int(os.getenv("TRIGGER_ANYWHERE", default=0)) == 1
 
 intents = discord.Intents.all()
+
 db = Connection(DATABASE)
 
 botID = None
@@ -348,13 +350,13 @@ def replaceRands(msgIn, randCount, messageObj):
     return msgOut
 
 
-def main():
-    bot.add_cog(general.General(bot, GH_user, GH_token, GH_repo))
-    bot.add_cog(info.Information(bot, WEATHERAPIKEY))
-    bot.add_cog(inventory.Inventory(bot, db))
-    bot.add_cog(factoids.Factoids(bot, db, OWNER, TRIGGER_ANYWHERE))
-    bot.run(TOKEN)
+async def main():
+    await bot.add_cog(general.General(bot, GH_user, GH_token, GH_repo))
+    await bot.add_cog(info.Information(bot, WEATHERAPIKEY))
+    await bot.add_cog(inventory.Inventory(bot, db))
+    await bot.add_cog(factoids.Factoids(bot, db, OWNER, TRIGGER_ANYWHERE))
+    await bot.start(TOKEN)
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/dist-env
+++ b/dist-env
@@ -1,0 +1,9 @@
+# never commit this file
+
+DISCORD_TOKEN="Your token Here!"
+DATABASE="yourtablesinwaiting.db"
+GITHUB=urname,urapikey,DickieBot2
+OWNER="discord-snowflake-id"
+OWMAPIKEY=""
+
+# https://discord.com/api/oauth2/authorize?client_id=955655070207328256&permissions=292057984064&scope=bot

--- a/log/.gitignore
+++ b/log/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 discord.py
+emoji
 fandom-py
 pyowm
+python-dateutil
+python-dotenv
 requests
 wikipedia


### PR DESCRIPTION
- Update requirements.txt so it runs in the python container
- Add a more general .db gitignore
- Setup keeping the logs directory since it expects it to be there and nothing creates it
- Update main to run against python 3.11 and a newer discord.py that wants async add_cog/load_extension
- Add a start on an example .env file