### PR TITLE
Update DickieBot.py item handling

### DIFF
--- a/DickieBot.py
+++ b/DickieBot.py
@@ -255,6 +255,12 @@ async def on_message(message):
         db.updateLastFact(message.guild.id, id, message.channel.id)
         db.updateLastCalled(id)
 
+    # Replace $1item variables with the same random inventory item
+    itemCount = msgOut.count("$1item") if msgOut is not None else 0
+    if itemCount > 0:
+        randItem = db.getInventoryItem(message.guild.id)
+        msgOut = msgOut.replace("$1item", randItem)
+        
     # Replace $item variables each with random inventory item
     itemCount = msgOut.count("$item") if msgOut is not None else 0
     for i in range(itemCount):

--- a/cogs/factoids.py
+++ b/cogs/factoids.py
@@ -285,7 +285,8 @@ class Factoids(commands.Cog):
                     Using !onnsfw marks the response as NSFW and will not be triggered in SFW channels.
                     Use $self to refer to the bot in the trigger. i.e. !on "Hi $self" -say Hello.
                     Use $rand, $nick, and $item in response to sub in a random user, the triggering user, and an inventory item, respectively.
-                    $item consumes the inventory item.
+                    Use $1item to reference the same inventory item every instance.
+                    $item and $1item consume the inventory item.
                     Using -react will expect a single emoji as the response arg. All reactions are SFW.""",
         brief="Teach me to respond to something",
     )


### PR DESCRIPTION
Add support for referencing one item multiple times in a factoid.

This would allow something like:
!onrand Hey $nick, you dropped $1item and I picked it up, but I like $1item a lot, so I'm going to give you $item instead and I'm going to keep $i1tem to give to $rand on their birthday. It will be the best $1item ever!